### PR TITLE
Adding function to generate auth token for SDK initialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terra-api",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "terra-api",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.5"

--- a/src/API/GenerateAuthToken.ts
+++ b/src/API/GenerateAuthToken.ts
@@ -1,0 +1,26 @@
+import { RequestWrapper, checkForServerSideAndWarn } from "./Helpers";
+export interface TerraAuthTokenResponse {
+  status: string;
+  token: string;
+  expires_in: number;
+}
+
+export function GenerateAuthToken(
+  devId: string,
+  apiKey: string
+): Promise<TerraAuthTokenResponse> {
+  checkForServerSideAndWarn();
+  const requestOptions = {
+    method: "POST",
+    headers: {
+      "X-API-Key": apiKey,
+      "dev-id": devId,
+      "Content-Type": "application/json",
+    },
+  };
+
+  return RequestWrapper<TerraAuthTokenResponse>(
+    "auth/generateAuthToken",
+    requestOptions
+  );
+}

--- a/src/API/GenerateWidgetSessions.ts
+++ b/src/API/GenerateWidgetSessions.ts
@@ -1,4 +1,4 @@
-import { RequestWrapper } from "./Helpers";
+import { RequestWrapper, checkForServerSideAndWarn } from "./Helpers";
 export interface TerraWidgetResponse {
   session_id: string;
   status: string;
@@ -14,6 +14,7 @@ export function GenerateWidgetSession(
   auth_success_redirect_url?: string,
   auth_failure_redirect_url?: string
 ): Promise<TerraWidgetResponse> {
+  checkForServerSideAndWarn();
   var raw = JSON.stringify({
     reference_id: referenceId,
     providers: providers ? providers.join(",") : undefined,

--- a/src/API/Helpers.ts
+++ b/src/API/Helpers.ts
@@ -38,3 +38,16 @@ export function RequestWrapper<T>(
       .catch((error) => rej(error));
   });
 }
+
+export function checkForServerSideAndWarn() {
+  if (
+    typeof process !== "undefined" &&
+    process.release.name.search(/node|io.js/) !== -1
+  ) {
+    //This is good, we are running in node
+  } else {
+    console.warn(
+      "This script is not running in Node.js which means this is probably running on the client side which means you are exposing your API Key which is very dangerous"
+    );
+  }
+}

--- a/src/API/Terra.ts
+++ b/src/API/Terra.ts
@@ -5,6 +5,7 @@ import {
   GenerateWidgetSession,
   TerraWidgetResponse,
 } from "./GenerateWidgetSessions";
+import { GenerateAuthToken, TerraAuthTokenResponse } from "./GenerateAuthToken";
 import { GetProviders, TerraProvidersResponse } from "./Providers";
 import { GetSubscribers, TerraSubscriptionsResponse } from "./Subscribers";
 import { DeauthUser, GetUser, TerraUserResponse } from "./UserInfo";
@@ -19,6 +20,15 @@ export default class Terra {
   constructor(devID: string, apiKey: string) {
     this.devID = devID;
     this.apiKey = apiKey;
+  }
+
+  /**
+   * Generate an Auth Token to be used with the SDK initialization
+   *
+   * @returns {Promise<TerraAuthTokenResponse>} A promise of type Auth Token Response
+   */
+  generateAuthToken(): Promise<TerraAuthTokenResponse> {
+    return GenerateAuthToken(this.devID, this.apiKey);
   }
 
   /**


### PR DESCRIPTION
Since this library is titled generic 'terra-api', it can run on client or server side. We are running it on the server side to generate widget sessions and also need to generate auth tokens for the client side SDK initialization. 

This PR adds a function to generate the auth token and also adds a check to make sure that any calls to the widget session or auth token generators are running in a node process to avoid someone accidentally calling it from client side and exposing their API Keys. Not 100% sure my check covers all cases but it just logs a console warning so the impact should be minimal if I missed anything. Definitely open to feedback/changes!