### PR TITLE
fix: add provider rate limit as payload type + check for 429 response…

### DIFF
--- a/src/API/Helpers.ts
+++ b/src/API/Helpers.ts
@@ -33,6 +33,15 @@ export function RequestWrapper<T>(
           } as TerraPayload);
           return;
         }
+        // rate limiting from providers end
+        else if (response.status === 429){
+          rej({
+            status: 'error',
+            type: 'provider_rate_limit',
+            message: response.status.toString(),
+          } as TerraPayload);
+          return;
+        }
         response
           .json()
           .then((result) => (response.ok ? res(result as T) : rej(result as TerraPayload)))

--- a/src/API/WebhookEvents.ts
+++ b/src/API/WebhookEvents.ts
@@ -20,7 +20,8 @@ type EventType =
   | 'access_revoked'
   | 'deauth'
   | 'internal_server_error'
-  | 'unknown';
+  | 'unknown'
+  | 'provider_rate_limit';
 
 export interface TerraPayload {
   status: EventStatus;


### PR DESCRIPTION
… and handle accordingly

1. Create new terra payload type
2. Check for 429 status
3. Handle 429 with response type accordingly