### PR TITLE
Add avg_saturation_percentage to Sleep interface

### DIFF
--- a/src/models/Sleep.ts
+++ b/src/models/Sleep.ts
@@ -94,6 +94,7 @@ export interface Sleep {
       start_time: Option<string>;
       end_time: Option<string>;
       samples: Array<OxygenSaturationSample>;
+      avg_saturation_percentage: Option<number>;
     };
   };
 }


### PR DESCRIPTION
This PR adds the missing `avg_saturation_percentage` field to the `Sleep` interface under `respiration_data.oxygen_saturation_data`.

This value is returned by the Terra API and was previously unrepresented in the model.

Fixes #32
